### PR TITLE
Fix eccentricity equation from R, V

### DIFF
--- a/coe_from_rv.m
+++ b/coe_from_rv.m
@@ -65,7 +65,7 @@ function [h, e, i, omega, w, theta] = coe_from_rv(R,V,mu)
     
     %% Calculate the eccentricity
     
-    E = (1 / mu)*((v^2 - (mu / r))*R - r*vr*V);
+    E = (1 / mu)*((v^2 - (mu / r))*R - vr*V);
     e = norm(E);
     
     %% Calculate the argument of perigee

--- a/kepler_convert.m
+++ b/kepler_convert.m
@@ -53,7 +53,7 @@ function kepler = kepler_convert(R,V,mu)
     
     %% Calculate the eccentricity
     
-    E = (1 / mu)*((v^2 - (mu / r))*R - r*vr*V);
+    E = (1 / mu)*((v^2 - (mu / r))*R - vr*V);
     e = norm(E);
     
     %% Calculate the argument of perigee


### PR DESCRIPTION
I noticed what appears to be an errant factor of |R| floating around in a couple of your eccentricity equations, which I believe was there in error. [Wikipedia](https://en.wikipedia.org/wiki/Eccentricity_vector), [BMW's Fundamentals of Astrodynamics](http://cmp.felk.cvut.cz/~kukelova/pajdla/Bate,%20Mueller,%20and%20White%20-%20Fundamentals%20of%20Astrodynamics.pdf) (eqn 1.5-11 on page 26), and other sources corroborate this, as does my own implementation of your code which, without this fix, was giving some pretty wonky eccentricity values for objects circling the Earth.

I updated the equation where I found it, but I may have missed some implementations. I only found two in this form.